### PR TITLE
[camera] Fix enumerating cameras when camera is already open. JB#55117

### DIFF
--- a/src/gsttools/qgstutils.cpp
+++ b/src/gsttools/qgstutils.cpp
@@ -551,7 +551,8 @@ QVector<QGstUtils::CameraInfo> QGstUtils::enumerateCameras(GstElementFactory *fa
                 if (camera) {
                     if (gst_element_set_state(camera, GST_STATE_READY) != GST_STATE_CHANGE_SUCCESS) {
                         // no-op
-                    } else for (int i = 0; i <= max; ++i) {
+                    }
+                    for (int i = 0; i <= max; ++i) {
                         gint orientation = 0;
                         gint direction = QCamera::UnspecifiedPosition;
                         g_object_set(G_OBJECT(camera), "camera-device", i, NULL);


### PR DESCRIPTION
Some older droid versions (< 7) do not allow opening camera more than once
from same process when using old camera API. Recent changes to gst-droid make
it open camera already when gstreamer is set to ready state which is done
when enumerating cameras. Also the recent changes make needed camera
information available already before ready state so we don't have to wait
for camera to be in ready state and can just read the information.