### PR TITLE
[camera] Fix checking for supported color filters. JB#56523

### DIFF
--- a/src/plugins/gstreamer/camerabin/camerabinimageprocessing.h
+++ b/src/plugins/gstreamer/camerabin/camerabinimageprocessing.h
@@ -86,7 +86,7 @@ private:
     CameraBinSession *m_session;
     QMap<QCameraImageProcessingControl::ProcessingParameter, int> m_values;
 #ifdef HAVE_GST_PHOTOGRAPHY
-    QMap<GstPhotographyWhiteBalanceMode, QCameraImageProcessing::WhiteBalanceMode> m_mappedWbValues;
+    QMap<QCameraImageProcessing::WhiteBalanceMode, GstPhotographyWhiteBalanceMode> m_mappedWbValues;
     QMap<QCameraImageProcessing::ColorFilter, GstPhotographyColorToneMode> m_filterMap;
 #endif
     QCameraImageProcessing::WhiteBalanceMode m_whiteBalanceMode;


### PR DESCRIPTION
If gstreamer reported color filters which are not supported by QtMultimedia
the code used invalid list index causing a crash.